### PR TITLE
Use context instead of "self generated" context

### DIFF
--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -1131,11 +1131,12 @@ class sale_order_line(osv.osv):
                     'Please set one before choosing a product.')
             warning_msgs += _("No Pricelist ! : ") + warn_msg +"\n\n"
         else:
-            price = self.pool.get('product.pricelist').price_get(cr, uid, [pricelist],
-                    product, qty or 1.0, partner_id, {
+            context.update({
                         'uom': uom or result.get('product_uom'),
                         'date': date_order,
-                        })[pricelist]
+                        })
+            price = self.pool.get('product.pricelist').price_get(cr, uid, [pricelist],
+                    product, qty or 1.0, partner_id, context)[pricelist]
             if price is False:
                 warn_msg = _("Cannot find a pricelist line matching this product and quantity.\n"
                         "You have to change either the product, the quantity or the pricelist.")


### PR DESCRIPTION
Ignoring the main context is a bad idea because of many possible features on pricelists are not realizable when context informations are not given.