### PR TITLE
use global context on price_get in every cases

### DIFF
--- a/addons/sale/sale.py
+++ b/addons/sale/sale.py
@@ -1125,11 +1125,12 @@ class sale_order_line(osv.osv):
             uom2 = product_obj.uom_id
 
         if pricelist and partner_id:
+            ctx_product.update({
+                'uom': uom or result.get('product_uom'),
+                'date': date_order,
+                })
             price = self.pool['product.pricelist'].price_get(cr, uid, [pricelist],
-                    product, qty or 1.0, partner_id, {
-                        'uom': uom or result.get('product_uom'),
-                        'date': date_order,
-                        })[pricelist]
+                    product, qty or 1.0, partner_id, context=ctx_product)[pricelist]
         else:
             price = Product.price_get(cr, uid, [product], ptype='list_price', context=ctx_product)[product] or False
         result.update({'price_unit': price})


### PR DESCRIPTION
Let the pricelist object use the global context for price calculation also when a partner is set. This allows more flexible price features.